### PR TITLE
Add missing Commentary heading

### DIFF
--- a/turkish.el
+++ b/turkish.el
@@ -6,6 +6,7 @@
 ;; Keywords: turkish, languages, automatic, conversion
 ;; URL: http://www.denizyuret.com/2006/11/emacs-turkish-mode.html
 
+;;; Commentary:
 
 ;; Emacs Turkish Extension (c) Deniz Yuret, 2006, 2010
 


### PR DESCRIPTION
This enables package.el to parse out the full package description, e.g. for inclusion on the MELPA page for your package.
